### PR TITLE
Fix equals

### DIFF
--- a/lib/money.rb
+++ b/lib/money.rb
@@ -8,7 +8,7 @@ class Money
   end
 
   def equals(money)
-    amount == money.amount && self.class == money.class
+    amount == money.amount && currency == money.currency
   end
 
   # Javaと異なり、Rubyでの == は同一性の比較になる


### PR DESCRIPTION
10章で 本来、equals メソッドで、classではなく、通貨の比較を行うように修正すべきだった。
currency を比較するように修正。