### PR TITLE
Use Module

### DIFF
--- a/lib/expression.rb
+++ b/lib/expression.rb
@@ -1,4 +1,4 @@
-class Expression
+module Expression
   def reduce(to)
     raise NotImplementedError
   end

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -1,7 +1,9 @@
 require_relative 'expression'
 require_relative 'sum'
 
-class Money < Expression
+class Money
+  include Expression
+
   attr_accessor :amount
 
   def initialize(amount, currency)

--- a/lib/sum.rb
+++ b/lib/sum.rb
@@ -1,4 +1,6 @@
-class Sum < Expression
+class Sum
+  include Expression
+
   attr_accessor :augend
   attr_accessor :addend
 


### PR DESCRIPTION
Java の Interface を Ruby で表現するため、classの継承を利用していたが、
Interfaceを継承すると意味合いが異なってしまうため、本来の意味合いとしてより近い、module を使用するように修正。